### PR TITLE
Make the url dependency optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,13 +16,14 @@ serde_json = "1.0"
 tokio = { version = "1.49", features = ["process"], optional = true }
 chrono = { version = "0.4", features = ["serde"] }
 serde-value = "0.7.0"
-url = "2.5.8"
+url = { version = "2.5.8", optional = true }
 
 [features]
 default = ["chapters", "format", "streams"]
 streams = []
 format = []
 chapters = []
+url = ["dep:url"]
 
 async = ["dep:tokio"]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,6 @@ pub use streams::StreamTags;
 pub use subtitle_stream::SubtititleTags;
 #[cfg(feature = "streams")]
 pub use subtitle_stream::SubtitleStream;
-use url::Url;
 #[cfg(feature = "streams")]
 pub use video_stream::VideoStream;
 #[cfg(feature = "streams")]
@@ -117,7 +116,8 @@ impl<'a> IntoFfprobeArg<'a> for PathBuf {
     }
 }
 
-impl<'a> IntoFfprobeArg<'a> for Url {
+#[cfg(feature = "url")]
+impl<'a> IntoFfprobeArg<'a> for url::Url {
     fn into_ffprobe_arg(self) -> Cow<'a, str> {
         Cow::Owned(self.to_string())
     }


### PR DESCRIPTION
url is a huge crate, and it's only use is to implement IntoFfprobeArg for url::Url.
This is a huge bloat for a feature that won't be used most of the times.

I put the url crate under the "url" feature. I didn't put url as a default feature, because I felt like it would just bloat everyones installation, without them needing it 99% of the times. But this is a breaking change, so if you want, I can make it default. I still think is would be nice to allow opting out of it, if it's not needed. 

I would personally remove the url dependency completely. url::Url is convertible to String, so it should be easy to convert it, and it adds unnecessary overhead to the library. 

Also, if I use a different version than 2.5.8 for url, I won't even get the trait impl, since the dependency is fixed to that version.

If you want, I can change the PR to remove the dependency. 